### PR TITLE
Handle SES create receipt rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,24 @@ SnsSubscribeFunctionArn
 [sns.subscribe.template](test/aws/sns.subscribe.template)
 
 
+### Create a SES Receipt Rule
+
+Allows to create an SES Receipt Rule inside an existing SES Rule set (active or not).
+Mirrors the [SES.CreateReceipRule API method](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#createReceiptRule-property).
+This will delete the rule when the corresponding stack is deleted.
+
+#### Paramters
+
+See the reference above or the example below for full list of parameters. All parameters are directly passed 'as is' except boolean which are converted. 
+
+#### Reference Output Name
+SesCreateReceiptRuleFunctionArn
+
+#### Example/Test Template
+[ses.createReceiptRule.template](test/aws/ses.createReceiptRule.template)
+
+
+
 ## Deployment (contributors)
 After making changes (i.e. adding a new helper function), please do the following:
 

--- a/aws/ses.js
+++ b/aws/ses.js
@@ -1,0 +1,39 @@
+var Promise = require('bluebird'),
+    AWS = require('aws-sdk'),
+    base = require('lib/base'),
+    helpers = require('lib/helpers'),
+    ses = Promise.promisifyAll(new AWS.SES());
+    
+// Exposes the SES.createReceiptRule API method
+function CreateReceiptRule(event, context) {
+  base.Handler.call(this, event, context);
+}
+CreateReceiptRule.prototype = Object.create(base.Handler.prototype);
+CreateReceiptRule.prototype.handleCreate = function() {
+  var p = this.event.ResourceProperties;
+  delete p.ServiceToken;
+  p.Rule.Enabled = ("true" === p.Rule.Enabled );
+  p.Rule.ScanEnabled = ("true" === p.Rule.ScanEnabled );
+  return ses.createReceiptRuleAsync(p)
+    .then(function() {
+      return {
+        RuleSetName : p.RuleSetName,
+        RuleName : p.Rule.Name
+      }
+    });
+}
+CreateReceiptRule.prototype.handleDelete = function(referenceData) {
+  return Promise.try(function() {
+    if (referenceData) {
+      return ses.deleteReceiptRuleAsync({
+        RuleSetName : referenceData.RuleSetName,
+        RuleName : referenceData.RuleName
+      });
+    }
+  });
+}
+exports.createReceiptRule = function(event, context) {
+  console.log(JSON.stringify(event));
+  handler = new CreateReceiptRule(event, context);
+  handler.handle();
+}

--- a/create_cloudformation_helper_functions.template
+++ b/create_cloudformation_helper_functions.template
@@ -383,6 +383,61 @@
       "DependsOn": [
         "SnsSubscribeFunctionRole"
       ]
+    },
+    "SesCreateReceiptRuleFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [ "lambda.amazonaws.com" ]
+              },
+              "Action": [ "sts:AssumeRole" ]
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          { "Ref": "RoleBasePolicy" }
+        ],
+        "Policies": [
+          {
+            "PolicyName": "SESReceiptRuleModifier",
+            "PolicyDocument": {
+              "Version" : "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ses:CreateReceiptRule",
+                    "ses:DeleteReceiptRule"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "SesCreateReceiptRuleFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "com.gilt.public.backoffice",
+          "S3Key": "lambda_functions/cloudformation-helpers.zip"
+        },
+        "Description": "Used to create SES receipt rules.",
+        "Handler": "aws/ses.createReceiptRule",
+        "Role": {"Fn::GetAtt" : [ "SesCreateReceiptRuleFunctionRole", "Arn" ] },
+        "Runtime": "nodejs4.3",
+        "Timeout": 30
+      },
+      "DependsOn": [
+        "SesCreateReceiptRuleFunctionRole"
+      ]
     }
   },
   "Outputs": {
@@ -409,6 +464,10 @@
     "S3PutObjectFunctionArn": {
       "Description": "The ARN of the S3PutObjectFunction, for use in other CloudFormation templates.",
       "Value": { "Fn::GetAtt" : ["S3PutObjectFunction", "Arn"] }
+    },
+    "SesCreateReceiptRuleFunctionArn": {
+      "Description": "The ARN of the SesCreateReceiptRuleFunction, for use in other CloudFormation templates.",
+      "Value": { "Fn::GetAtt" : ["SesCreateReceiptRuleFunction", "Arn"] }
     }
   }
 }

--- a/test/aws/ses.createReceiptRule.template
+++ b/test/aws/ses.createReceiptRule.template
@@ -5,9 +5,17 @@
       "Type": "String",
       "Description": "The name of the stack where you installed the CloudFormation helper functions. See https://github.com/gilt/cloudformation-helpers."
     },
+    "RuleSetName": {
+      "Type": "String",
+      "Description": "The name of the rule set where to create the rule. Must already exist."
+    },
     "S3Bucket": {
       "Type": "String",
       "Description": "The name of the S3 bucket where to put the object. Must already exist."
+    },
+    "MailRecipient" :{
+      "Type": "String",
+      "Description": "Email used to receive mails in the configured rule"
     }
   },
   "Resources": {
@@ -27,24 +35,23 @@
         "CFHelperStack"
       ]
     },
-    "S3PutObject1": {
-      "Type": "Custom::S3PutObject",
+    "SesCreateReceiptRule": {
+      "Type": "Custom::SesCreateReceiptRule",
       "Properties": {
-        "ServiceToken": { "Fn::GetAtt" : ["CFHelper", "S3PutObjectFunctionArn"] },
-        "Bucket": { "Ref": "S3Bucket" },
-        "Key": "empty-dir/"
-      },
-      "DependsOn": [
-        "CFHelper"
-      ]
-    },
-    "S3PutObject2": {
-      "Type": "Custom::S3PutObject",
-      "Properties": {
-        "ServiceToken": { "Fn::GetAtt" : ["CFHelper", "S3PutObjectFunctionArn"] },
-        "Bucket": { "Ref": "S3Bucket" },
-        "Key": "new-dir/test.txt",
-        "Body": "Test data"
+        "ServiceToken": { "Fn::GetAtt" : ["CFHelper", "SesCreateReceiptRuleFunctionArn"] },
+        "Rule" : {
+          "Name": "Test-SESRule",
+          "Recipients" : [{ "Ref": "MailRecipient" }],
+          "Enabled" : true,
+          "ScanEnabled" : true,
+          "Actions" : [{
+            "S3Action": {
+               "BucketName": { "Ref": "S3Bucket" },
+               "ObjectKeyPrefix": "incoming_mails/"
+             }
+          }]
+        },
+        "RuleSetName" :{ "Ref": "RuleSetName" } 
       },
       "DependsOn": [
         "CFHelper"


### PR DESCRIPTION
I added a function to handle create receipt rule(s) in an existing rule set in SES.
 
Creation of the rule set is supposed to be already done, since only one active rule set can be used at a time, so automating the activation of rule sets through a stack could lead to very strange behaviour once multiple stacks are operating on different rule sets and activating them.